### PR TITLE
Client login: use the optional "team" parameter if provided

### DIFF
--- a/slack_client.js
+++ b/slack_client.js
@@ -33,6 +33,7 @@ Slack.requestCredential = function (options, credentialRequestCompleteCallback) 
   var loginUrl =
         'https://slack.com/oauth/authorize' +
         '?client_id=' + config.clientId +
+        ((options && options.team) ? '&team=' + options.team : '') +
         '&response_type=code' +
         '&scope=' + flatScope +
         '&redirect_uri=' + OAuth._redirectUri('slack', config) +


### PR DESCRIPTION
Slack allows you to provide a parameter `team` on OAuth which allows you to specify which team you would like to default the auth request to if the user has multiple teams.

This change makes it so that if `team` is specified in the options passed to `Slack.requestCredential` it will be passed on as a parameter to Slack.
